### PR TITLE
Bump node from v16 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ outputs:
   use-runner:
     description: 'The runner to use, either the primary or the fallback runner, based on availability'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This prevents the following warning emitted by Github when using the action:

> ⚠️ Warning: The following actions uses Node.js version which is deprecated and will be forced to run on node20: jimmygchen/runner-fallback-action@v1.

For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/